### PR TITLE
Remove Proxycurl entry from resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The goal of this repository is to document the **Modern Growth Stack**, moving a
 - [Apollo](https://apollo.io) - Massive database of B2B contacts with built-in enrichment features.
 - [Clay](https://clay.com) - The spreadsheet that fills itself. Integrates 50+ data providers to enrich lead lists using AI.
 - [Bright Data](https://brightdata.com) - Heavy-duty web data platform for large-scale extraction.
-- [Proxycurl](https://proxycurl.com) - API to pull fresh data from LinkedIn profiles and companies.
+- ~~[Proxycurl](https://proxycurl.com) - API to pull fresh data from LinkedIn profiles and companies.~~ (shut down, see [link](https://nubela.co/blog/goodbye-proxycurl/))
 
 ## Cold Outreach & Email AI
 *The engine for sending emails at scale with high deliverability.*


### PR DESCRIPTION
Updated README to reflect the shutdown of Proxycurl and added a reference link.