### PR TITLE
Add FindMeMail under Data Scraping & Enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The goal of this repository is to document the **Modern Growth Stack**, moving a
 - [Browse AI](https://browse.ai) - No-code web automation to extract data from any website and monitor changes.
 - [Clay](https://clay.com) - The spreadsheet that fills itself. Integrates 50+ data providers to enrich lead lists using AI.
 - [PhantomBuster](https://phantombuster.com) - The standard for automating actions and scraping data from LinkedIn, Instagram, and Google Maps.
+- [FindMeMail](https://findmemail.io) - Plain-English search across 32k+ companies for verified founder & decision-maker emails. Real-time SMTP verification, free tier (50 credits) or $200 one-time lifetime.
 
 ## Cold Outreach & Email AI
 *The engine for sending emails at scale with high deliverability.*


### PR DESCRIPTION
Adding FindMeMail to the Data Scraping & Enrichment section.

It fits the "turn a company name or profile into a verified email and data set" description from the section intro — that's literally the product. AI-powered natural-language search ("Series A fintech in NY") returns SMTP-verified founder/decision-maker emails from a 32k+ company DB.

Has a free tier (50 credits) so readers can test without commitment, plus a $200 one-time lifetime tier (no subscription, which is rare in this category).

Happy to revise wording, move sections, or trim — let me know.