### PR TITLE
feat: add gmapsscraper.io to Data Scraping & Enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The goal of this repository is to document the **Modern Growth Stack**, moving a
 - [Browse AI](https://browse.ai) - No-code web automation to extract data from any website and monitor changes.
 - [Clay](https://clay.com) - The spreadsheet that fills itself. Integrates 50+ data providers to enrich lead lists using AI.
 - [PhantomBuster](https://phantombuster.com) - The standard for automating actions and scraping data from LinkedIn, Instagram, and Google Maps.
+- [gmapsscraper.io](https://gmapsscraper.io) - Dedicated Google Maps lead extraction API; pulls business names, phones, emails, addresses, and reviews at scale.
 
 ## Cold Outreach & Email AI
 *The engine for sending emails at scale with high deliverability.*


### PR DESCRIPTION
## What this adds

[gmapsscraper.io](https://gmapsscraper.io) added to the **Data Scraping & Enrichment** section, next to PhantomBuster (which already covers Google Maps as a use case).

gmapsscraper.io is a dedicated Google Maps lead extraction API — it pulls business names, phones, emails, addresses, and reviews at scale. Useful for lead gen workflows, local SEO research, and market analysis pipelines.

Fits naturally alongside tools like PhantomBuster and Apify in the scraping/enrichment category.